### PR TITLE
Add Claude skills / Copilot mapping post

### DIFF
--- a/content/posts/claude-skills-copilot-mapping/index.md
+++ b/content/posts/claude-skills-copilot-mapping/index.md
@@ -1,0 +1,193 @@
+---
+title: "Claude Skills and the Copilot Parallel : A Practitioner's Map"
+date: 2026-04-18T08:00:00-04:00
+description: "What Claude's skill system is, how it works, and how its concepts map onto the Microsoft 365 Copilot ecosystem --- and why the architecture explains the experience gap practitioners keep running into."
+summary: "A practitioner who built a Gmail triage workflow in Claude in an hour was told it would take 3–5 hours in Copilot using Power Automate. That gap is real --- and it's architectural. Here is how Claude's skill system maps to M365 Copilot, and what the comparison reveals about where each system was designed to be used."
+tags: ["ai", "claude", "copilot", "agents", "workflow"]
+categories: ["experiments"]
+draft: false
+---
+
+A colleague of mine --- a sharp product manager who runs excellent hackathons --- asked me a question that stuck. She had built an automated workflow in Claude : it pulls emails from Gmail, analyses them, flags them, and drafts a response back to her with the results. It took her about an hour to build, tune, and test.
+
+She then asked Microsoft Copilot if it could do something similar. The answer : use Power Automate to string the steps together, budget three to five hours.
+
+Her question to me was : **is Copilot Studio the key to doing this properly, or is that gap just the reality of the system?**
+
+I had been thinking about this question already, from a different angle. I had recently built a translation localisation agent in Copilot Studio at Sage --- an orchestrator that routes document localisation jobs to specialist child agents, each carrying the right regional rules, terminology, and formatting for a specific country and product. While building it, I kept noticing that the architecture I was reaching for looked a lot like something I'd seen in Claude's skill system : discrete, composable agents coordinated by a higher-level orchestrator, each doing one thing well.
+
+That parallel prompted the question I want to work through here : **how does Claude's skill architecture map to the Microsoft 365 Copilot ecosystem, and what does the comparison reveal about where the experience gap comes from?**
+
+## Goal
+
+To build a working mental model of Claude skills --- how they are structured, how they trigger, how they load --- and then map each layer to its closest equivalent in M365 Copilot. The aim is a practical translation guide, not a feature comparison. And at the end, I want to come back to the question my colleague asked and give it a real answer.
+
+## Working assumption
+
+Both systems are solving the same problem : how do you give an AI agent specialised, reusable, contextually loaded instructions without bloating every conversation with everything it might ever need to know?
+
+The architectures differ. The intent is the same. Understanding one helps you reason about the other --- and helps you understand why the same task takes different amounts of time in each.
+
+---
+
+## What a Claude skill actually is
+
+A Claude skill is a structured, installable bundle of instructions. At its core it is a folder with a required `SKILL.md` file and optional supporting resources.
+
+```
+skill-name/
+├── SKILL.md              ← instructions + trigger description
+└── (optional)
+    ├── scripts/          ← executable code for deterministic tasks
+    ├── references/       ← supporting docs loaded on demand
+    └── assets/           ← templates, fonts, output files
+```
+
+The `.skill` file format is just this folder packaged for portability --- install it, and it unpacks into the environment where Claude can detect and use it.
+
+### The SKILL.md file
+
+Every skill has a `SKILL.md` with two parts.
+
+**YAML frontmatter** at the top :
+
+```yaml
+---
+name: your-skill-name
+description: What it does and when to use it.
+---
+```
+
+**Markdown body** below the frontmatter : the actual instructions Claude follows when the skill activates. The body uses plain imperative markdown --- tell Claude what to do, why it matters, and what the output should look like.
+
+### The trigger mechanism
+
+The `description` field in the frontmatter is the primary trigger. Claude sees only the skill name and description when deciding whether to consult it --- the full body is not in context until the skill activates. This means the description has to do real work : it needs to be specific enough to trigger on the right prompts and general enough not to miss adjacent cases.
+
+The guidance from the skill system itself is to make descriptions slightly "pushy" --- list the kinds of phrases and contexts that should activate the skill, because undertriggering is the common failure mode.
+
+---
+
+## The three-level loading system
+
+Claude skills use a progressive disclosure model that keeps context lean :
+
+| Level | What loads | When |
+|---|---|---|
+| **Metadata** | name + description only | Always in context |
+| **SKILL.md body** | Full instructions | On trigger |
+| **Bundled resources** | Scripts, references, assets | On demand, as needed |
+
+Large reference documents live in `references/` and are only pulled into context when the instructions explicitly call for them. Scripts in `scripts/` can execute without being read into the context window at all.
+
+This matters because it means a skill can carry a lot of supporting material --- brand guidelines, schema definitions, output templates --- without paying a context cost upfront.
+
+---
+
+## Mapping to the Microsoft 365 Copilot ecosystem
+
+Now the translation.
+
+### Skill = Copilot Studio declarative agent or custom agent
+
+The closest direct equivalent to a Claude skill is a **declarative agent** in Microsoft Copilot Studio --- a configured agent with a defined scope, instructions, and optional knowledge sources and actions. Both are :
+
+- Packaged and installable
+- Driven by a description that determines when they activate
+- Carrying instructions separate from the base model
+- Extensible with tools and references
+
+The difference is surface : Claude skills are file-system-based, authored in markdown. Copilot declarative agents are configured in the Studio UI or via YAML manifests, deployed through Teams or M365 admin.
+
+### SKILL.md frontmatter = agent manifest / system prompt
+
+In Copilot Studio, the equivalent of the `SKILL.md` frontmatter is the **agent manifest** (the `declarativeAgent.json` or the "Configure" panel in Studio). The `description` field maps directly to the agent's scope and purpose statement, which also functions as a trigger signal in orchestration.
+
+The markdown body of `SKILL.md` --- the imperative instructions --- maps to the **system prompt** or **instructions block** of a Copilot agent. Both define behaviour : tone, output format, constraints, step sequences.
+
+### Bundled resources = knowledge sources + SharePoint grounding
+
+The `references/` folder in a Claude skill --- documents loaded selectively into context --- maps to **knowledge sources** in Copilot Studio : SharePoint sites, uploaded files, or Graph-indexed content that the agent retrieves when relevant. Both follow a similar principle : don't load everything upfront; pull what the task needs.
+
+The `assets/` folder (templates, output files) has a rougher equivalent in SharePoint document libraries or OneDrive content that agents reference or generate outputs into.
+
+### Scripts = Power Automate actions / connectors
+
+The `scripts/` folder in a Claude skill --- executable code for deterministic, repeatable tasks --- maps most directly to **Power Automate flows** and **connector actions** in Copilot Studio. Both extend the agent's capability beyond conversation into real operations : creating files, calling APIs, transforming data, triggering downstream workflows.
+
+The conceptual difference worth noting : Claude skill scripts are typically Python or bash running in a sandboxed compute environment, with broad flexibility. Power Automate actions are more constrained by connector availability but are natively integrated with the M365 surface --- Teams, Outlook, SharePoint, Dataverse.
+
+### Progressive disclosure = token budget management in Copilot
+
+This one does not have a named equivalent in Copilot Studio, but the problem it solves is the same : how do you give an agent access to a lot of specialised knowledge without exceeding the context window or degrading response quality?
+
+In Copilot, this is managed through **retrieval-augmented generation (RAG)** against indexed knowledge sources --- the agent does not hold all documents in context; it retrieves relevant chunks at query time. Claude skills handle this more manually, through explicit `view` calls on reference files when the instructions direct it. The outcome is similar : context stays lean, depth loads on demand.
+
+### Packaging and deployment = solution packages / app manifests
+
+A `.skill` file --- the packaged folder --- maps to a **Teams app manifest** or **solution package** in the Copilot / Power Platform ecosystem. Both are portable, versioned, installable artefacts. A `.skill` unpacks into a file directory. A Teams app manifest deploys an agent into a tenant.
+
+---
+
+## Quick recap : the mapping table
+
+| Claude skill concept | M365 Copilot equivalent |
+|---|---|
+| `.skill` file (packaged bundle) | Teams app manifest / solution package |
+| `SKILL.md` frontmatter `description` | Agent manifest scope / purpose statement |
+| `SKILL.md` body (instructions) | Agent system prompt / instructions block |
+| `references/` folder | Knowledge sources (SharePoint, uploaded files) |
+| `scripts/` folder | Power Automate flows / connector actions |
+| `assets/` folder | SharePoint document libraries / templates |
+| Progressive disclosure (3-level load) | RAG retrieval against indexed knowledge |
+| Trigger from description match | Agent routing in Copilot orchestration |
+
+---
+
+## What the comparison surfaces
+
+A few observations the mapping makes explicit.
+
+**Trigger design is underrated in both systems.** In Claude, undertriggering is the documented failure mode --- skills don't activate when they should. In Copilot Studio, the equivalent failure is agents that don't route correctly in multi-agent or handoff scenarios. In both cases the fix is the same : be more specific and explicit in the description / scope statement, not less.
+
+**Portability differs by design.** A `.skill` file is filesystem-portable --- copy it, install it anywhere Claude runs. A Copilot declarative agent is tenant-bound and Teams-surface-bound. This is a real architectural difference, not just tooling. Claude skills are closer to the open-source plugin model; Copilot agents are closer to enterprise app deployment.
+
+**The abstraction layer is different.** Claude skills put the instructions in a markdown file you write and own. Copilot Studio puts them in a UI panel backed by a JSON manifest. For practitioners who think in code and text, the Claude model is more transparent. For teams working in enterprise M365 without a developer profile, the Studio model is more accessible.
+
+---
+
+## The gap I keep running into
+
+I want to be direct about something the mapping table above glosses over.
+
+Anthropic's skill system is well-designed end to end. You write a markdown file. You drop supporting scripts and references into folders next to it. You package it with a single command and hand off a `.skill` file. Someone else installs it. The whole loop --- create, test, iterate, share --- runs in plain text, in a terminal, with tools any practitioner already has. There is no portal, no tenant admin, no approval queue.
+
+Microsoft's analogue is cumbersome by comparison, and I say that as someone who has spent real time building in Copilot Studio.
+
+To create a declarative agent, you work through a UI that abstracts away the underlying manifest. To share it, you publish to Teams admin, request organisational deployment, or package a manifest through the Developer Portal --- a process that involves app registration, admin consent, and tenant-level policy depending on your organisation's configuration. To iterate, you cycle back through the same UI and republish.
+
+The experience reflects the difference in design philosophy. Claude skills are built for practitioners who own their environment. Copilot agents are built for enterprise IT governance. Both are coherent given their context --- but the practical effect is that building and sharing a Claude skill takes an afternoon, while standing up a comparable Copilot agent for team use can take days and requires people beyond the builder.
+
+---
+
+## Back to the original question
+
+My colleague asked : is Copilot Studio the key, or is the gap just the reality of the system?
+
+The honest answer is : both.
+
+Copilot Studio is the correct tool if you are building inside M365 --- agents that read email from Outlook, act on SharePoint documents, trigger Teams notifications, or route into Dataverse. The native surface integration is real and the value is real. The translation localisation agent I built at Sage lives inside our tenant, accesses our SharePoint-hosted glossaries, and routes to sub-agents through Teams --- none of that would work in Claude without significant infrastructure work.
+
+But for the kind of workflow my colleague described --- connecting to external services, pulling from Gmail, building a personal triage loop that runs end to end --- Claude is a fundamentally different experience. Not because Claude is "better," but because it is designed for a different builder profile. The skill system, the tool use model, the scripting layer : they are all optimised for a practitioner who is building for themselves, iterating fast, and owns the compute. The M365 system is optimised for a practitioner who is building for an organisation, deploying to others, and operating inside IT governance.
+
+The three-to-five hour estimate for Power Automate is not a capability failure. It is the cost of building inside enterprise infrastructure. That cost is sometimes worth it --- when the distribution, the security, the audit trail, or the surface integration matters. It is sometimes not worth it --- when you are validating an idea and need to know if it works before you invest in the deployment layer.
+
+Understanding the architecture helps you make that call clearly, rather than assuming one system is behind the other.
+
+---
+
+## Next step
+
+The comparison raises a practical question I want to test : can the skill architecture pattern --- description-as-trigger, progressive disclosure, bundled references --- inform how I structure Copilot Studio agent instructions and knowledge sources? Specifically, whether splitting system prompt from knowledge sources in the same way that `SKILL.md` body separates from `references/` produces more reliable, focused agent behaviour in Studio.
+
+That is the next experiment.


### PR DESCRIPTION
Practitioner's map of how Claude's .skill architecture maps to M365 Copilot, with expanded intro and closing framing the experience gap (Claude ~1 hr vs. Power Automate 3–5 hrs) as an architectural difference, not a capability one.